### PR TITLE
Prevent Glyphs from drawing anchor cloud for active layer

### DIFF
--- a/ShowAnchorCloud.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowAnchorCloud.glyphsReporter/Contents/Resources/plugin.py
@@ -109,3 +109,6 @@ class ShowAnchorCloud(ReporterPlugin):
         except:
             print("Oops!", sys.exc_info()[0], "occured.")
             traceback.print_exc(file=sys.stdout)
+
+    def shouldDrawAccentCloudForLayer_(self, layer):
+        return layer != self.activeLayer()


### PR DESCRIPTION
Otherwise the anchor cloud is drawn twice. Glyphs also will draw anchor cloud for all the anchors, not only the selected one, while we want to draw anchor cloud for the selected anchor only.

Since we draw only for the active layer, keep Glyphs anchor cloud for the inactive ones (i.e. other glyphs shown in the glyph view).